### PR TITLE
Fontawesome v5

### DIFF
--- a/Thorfile
+++ b/Thorfile
@@ -20,11 +20,6 @@ module Middleman
       run 'mv source/rails-stylesheets-master source/stylesheets'
       run 'mv source/stylesheets/application.scss source/stylesheets/application.css.scss'
       run 'rm source/stylesheets/README.md'
-      if RUBY_PLATFORM =~ /darwin/ # OSX
-        run "sed -i '' '/font-awesome-sprockets/d' ./source/stylesheets/application.css.scss"
-      else
-        run "sed -i '/font-awesome-sprockets/d' ./source/stylesheets/application.css.scss"
-      end
       run 'rm source/stylesheets/pages/_home.scss && mv source/home.scss source/stylesheets/pages/_home.scss'
       run 'mv source/about.scss source/stylesheets/pages/_about.scss'
       run 'echo "@import \"about\";" >> source/stylesheets/pages/_index.scss'


### PR DESCRIPTION
We now use the same gem for `rails` and `middleman` apps, so no need to remove the `font-awesome-spockets`

if you want to test the template I have created my own template with an `<i>` tag on the index and used the modified Thorfile to see if it worked:
```
middleman init test-template -B -T arthur-littm/middleman-template
cd test-template
bundle install
middleman serve
```